### PR TITLE
Fix task creation spinner stuck and re-login after force quit

### DIFF
--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/setup/SetupViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/setup/SetupViewModel.kt
@@ -268,22 +268,20 @@ class SetupViewModel @Inject constructor(
         }
     }
 
-    private fun createBackupApiToken() {
-        viewModelScope.launch {
-            try {
-                val expiry = Instant.now().plusSeconds(365L * 24 * 60 * 60)
-                val expiryStr = DateTimeFormatter.ISO_INSTANT.format(expiry)
-                val request = ApiTokenRequestDto(
-                    title = "Vicu Android Backup",
-                    expiresAt = expiryStr,
-                )
-                val response = apiService.get().createApiToken(request)
-                if (response.token.isNotBlank()) {
-                    authManager.onApiTokenSaved(response.token, expiry.epochSecond)
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Backup API token creation failed (non-fatal)", e)
+    private suspend fun createBackupApiToken() {
+        try {
+            val expiry = Instant.now().plusSeconds(365L * 24 * 60 * 60)
+            val expiryStr = DateTimeFormatter.ISO_INSTANT.format(expiry)
+            val request = ApiTokenRequestDto(
+                title = "Vicu Android Backup",
+                expiresAt = expiryStr,
+            )
+            val response = apiService.get().createApiToken(request)
+            if (response.token.isNotBlank()) {
+                authManager.onApiTokenSaved(response.token, expiry.epochSecond)
             }
+        } catch (e: Exception) {
+            Log.w(TAG, "Backup API token creation failed (non-fatal)", e)
         }
     }
 }


### PR DESCRIPTION
Bug 1: Wrap save() coroutine body in try-catch so isSaving is always
reset to false, even if label attachment or task refresh throws an
unexpected exception or hangs due to auth issues.

Bug 2: Change createBackupApiToken() from fire-and-forget to an awaited
suspend function. Previously, if the backup token request failed silently,
no API token was persisted — causing re-login when the JWT expired and
TokenAuthenticator had no fallback token.

https://claude.ai/code/session_0188DbDqAhuNEKEwxVKuLNS5