### PR TITLE
Widget improvements, drawer reorder, and HTTP support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.rendyhd.vicu"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "1.0.14"
+        versionCode = 16
+        versionName = "1.0.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,9 @@ dependencies {
     implementation(libs.appauth)
     implementation(libs.tink.android)
 
+    // Reorderable (drag-and-drop)
+    implementation(libs.reorderable)
+
     // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/rendyhd/vicu/MainActivity.kt
+++ b/app/src/main/java/com/rendyhd/vicu/MainActivity.kt
@@ -34,6 +34,8 @@ class MainActivity : ComponentActivity() {
 
     private val _initialTaskId = MutableStateFlow<Long?>(null)
     private val _showTaskEntry = MutableStateFlow(false)
+    private val _showTaskEntryProjectId = MutableStateFlow<Long?>(null)
+    private val _navigateToView = MutableStateFlow<Pair<String, String>?>(null)
     private val _sharedContent = MutableStateFlow<SharedContent?>(null)
 
     private val notificationPermissionLauncher = registerForActivityResult(
@@ -65,7 +67,13 @@ class MainActivity : ComponentActivity() {
                     initialTaskId = _initialTaskId,
                     onInitialTaskConsumed = { _initialTaskId.value = null },
                     showTaskEntry = _showTaskEntry,
-                    onShowTaskEntryConsumed = { _showTaskEntry.value = false },
+                    showTaskEntryProjectId = _showTaskEntryProjectId,
+                    onShowTaskEntryConsumed = {
+                        _showTaskEntry.value = false
+                        _showTaskEntryProjectId.value = null
+                    },
+                    navigateToView = _navigateToView,
+                    onNavigateToViewConsumed = { _navigateToView.value = null },
                     sharedContent = _sharedContent,
                     onSharedContentConsumed = { _sharedContent.value = null },
                 )
@@ -87,6 +95,16 @@ class MainActivity : ComponentActivity() {
         }
         if (intent.getBooleanExtra("show_task_entry", false)) {
             _showTaskEntry.value = true
+            val projectId = intent.getLongExtra("default_project_id", 0L)
+            if (projectId != 0L) {
+                _showTaskEntryProjectId.value = projectId
+            }
+        }
+
+        val navViewType = intent.getStringExtra("navigate_to_view_type")
+        if (!navViewType.isNullOrBlank()) {
+            val navViewId = intent.getStringExtra("navigate_to_view_id") ?: ""
+            _navigateToView.value = navViewType to navViewId
         }
 
         when (intent.action) {

--- a/app/src/main/java/com/rendyhd/vicu/data/local/CustomListStore.kt
+++ b/app/src/main/java/com/rendyhd/vicu/data/local/CustomListStore.kt
@@ -63,6 +63,23 @@ class CustomListStore @Inject constructor(
         context.customListDataStore.edit { it.clear() }
     }
 
+    suspend fun reorder(fromIndex: Int, toIndex: Int) {
+        context.customListDataStore.edit { prefs ->
+            val current = prefs[KEY_LISTS]?.let {
+                try {
+                    json.decodeFromString(ListSerializer(CustomList.serializer()), it).toMutableList()
+                } catch (_: Exception) {
+                    mutableListOf()
+                }
+            } ?: return@edit
+
+            if (fromIndex !in current.indices || toIndex !in current.indices) return@edit
+            val item = current.removeAt(fromIndex)
+            current.add(toIndex, item)
+            prefs[KEY_LISTS] = json.encodeToString(ListSerializer(CustomList.serializer()), current)
+        }
+    }
+
     suspend fun delete(id: String) {
         context.customListDataStore.edit { prefs ->
             val current = prefs[KEY_LISTS]?.let {

--- a/app/src/main/java/com/rendyhd/vicu/data/local/WidgetPrefsStore.kt
+++ b/app/src/main/java/com/rendyhd/vicu/data/local/WidgetPrefsStore.kt
@@ -1,0 +1,44 @@
+package com.rendyhd.vicu.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.widgetPrefsDataStore: DataStore<Preferences> by preferencesDataStore(name = "widget_prefs")
+
+@Singleton
+class WidgetPrefsStore @Inject constructor(
+    private val context: Context,
+) {
+    companion object {
+        private val KEY_SMART_ADD = booleanPreferencesKey("widget_smart_add")
+        private val KEY_CONTEXT_NAV = booleanPreferencesKey("widget_context_nav")
+    }
+
+    val smartAdd: Flow<Boolean> = context.widgetPrefsDataStore.data.map { prefs ->
+        prefs[KEY_SMART_ADD] ?: true
+    }
+
+    val contextNav: Flow<Boolean> = context.widgetPrefsDataStore.data.map { prefs ->
+        prefs[KEY_CONTEXT_NAV] ?: true
+    }
+
+    suspend fun setSmartAdd(enabled: Boolean) {
+        context.widgetPrefsDataStore.edit { prefs ->
+            prefs[KEY_SMART_ADD] = enabled
+        }
+    }
+
+    suspend fun setContextNav(enabled: Boolean) {
+        context.widgetPrefsDataStore.edit { prefs ->
+            prefs[KEY_CONTEXT_NAV] = enabled
+        }
+    }
+}

--- a/app/src/main/java/com/rendyhd/vicu/data/repository/ProjectRepositoryImpl.kt
+++ b/app/src/main/java/com/rendyhd/vicu/data/repository/ProjectRepositoryImpl.kt
@@ -36,8 +36,20 @@ class ProjectRepositoryImpl @Inject constructor(
     override suspend fun create(project: Project): NetworkResult<Project> =
         NetworkResult.Error("Not yet implemented")
 
-    override suspend fun update(project: Project): NetworkResult<Project> =
-        NetworkResult.Error("Not yet implemented")
+    override suspend fun update(project: Project): NetworkResult<Project> {
+        return try {
+            val dto = with(projectMapper) { project.toDto() }
+            val entity = with(projectMapper) { dto.toEntity() }
+            projectDao.upsert(entity)
+            val responseDto = api.updateProject(project.id, dto)
+            val responseEntity = with(projectMapper) { responseDto.toEntity() }
+            projectDao.upsert(responseEntity)
+            NetworkResult.Success(with(projectMapper) { responseEntity.toDomain() })
+        } catch (_: Exception) {
+            // Optimistic update already saved locally
+            NetworkResult.Success(project)
+        }
+    }
 
     override suspend fun delete(projectId: Long): NetworkResult<Unit> =
         NetworkResult.Error("Not yet implemented")

--- a/app/src/main/java/com/rendyhd/vicu/data/repository/TaskRepositoryImpl.kt
+++ b/app/src/main/java/com/rendyhd/vicu/data/repository/TaskRepositoryImpl.kt
@@ -295,6 +295,7 @@ class TaskRepositoryImpl @Inject constructor(
             val safeEntities = entities.filter { it.id !in pendingTaskIds }
             taskDao.upsertAll(safeEntities)
             alarmScheduler.rescheduleAll()
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(context)
             Log.d(TAG, "refreshAll() SUCCESS: upserted ${safeEntities.size} total tasks (skipped ${entities.size - safeEntities.size} with pending actions)")
             NetworkResult.Success(Unit)
         } catch (e: Exception) {

--- a/app/src/main/java/com/rendyhd/vicu/domain/model/CustomList.kt
+++ b/app/src/main/java/com/rendyhd/vicu/domain/model/CustomList.kt
@@ -14,6 +14,7 @@ data class CustomList(
 data class CustomListFilter(
     val projectIds: List<Long> = emptyList(),
     val projectFilterMode: String = "include", // "include" or "exclude"
+    val addToProjectId: Long = 0L, // 0 = inbox (default)
     val sortBy: String = "due_date",
     val orderBy: String = "asc",
     val dueDateFilter: String = "all",

--- a/app/src/main/java/com/rendyhd/vicu/domain/model/CustomList.kt
+++ b/app/src/main/java/com/rendyhd/vicu/domain/model/CustomList.kt
@@ -13,6 +13,7 @@ data class CustomList(
 @Serializable
 data class CustomListFilter(
     val projectIds: List<Long> = emptyList(),
+    val projectFilterMode: String = "include", // "include" or "exclude"
     val sortBy: String = "due_date",
     val orderBy: String = "asc",
     val dueDateFilter: String = "all",

--- a/app/src/main/java/com/rendyhd/vicu/ui/VicuApp.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/VicuApp.kt
@@ -319,6 +319,8 @@ fun VicuApp(
                     scope.launch { drawerState.close() }
                     showNewListDialog = true
                 },
+                onReorderProject = drawerViewModel::reorderProject,
+                onReorderList = drawerViewModel::reorderCustomList,
             )
         },
     ) {
@@ -412,6 +414,7 @@ fun VicuApp(
                 navController.navigate(CustomListRoute(list.id))
             },
             onDismiss = { showNewListDialog = false },
+            inboxProjectId = drawerUiState.inboxProjectId,
         )
     }
 }

--- a/app/src/main/java/com/rendyhd/vicu/ui/VicuApp.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/VicuApp.kt
@@ -119,7 +119,10 @@ fun VicuApp(
     initialTaskId: kotlinx.coroutines.flow.StateFlow<Long?>? = null,
     onInitialTaskConsumed: () -> Unit = {},
     showTaskEntry: kotlinx.coroutines.flow.StateFlow<Boolean>? = null,
+    showTaskEntryProjectId: kotlinx.coroutines.flow.StateFlow<Long?>? = null,
     onShowTaskEntryConsumed: () -> Unit = {},
+    navigateToView: kotlinx.coroutines.flow.StateFlow<Pair<String, String>?>? = null,
+    onNavigateToViewConsumed: () -> Unit = {},
     sharedContent: kotlinx.coroutines.flow.StateFlow<SharedContent?>? = null,
     onSharedContentConsumed: () -> Unit = {},
 ) {
@@ -148,13 +151,39 @@ fun VicuApp(
         }
     }
 
-    // Handle widget deep link → open TaskEntrySheet
+    // Handle widget deep link → open TaskEntrySheet (optionally with project)
     val showTaskEntryValue = showTaskEntry?.collectAsStateWithLifecycle()?.value
+    val showTaskEntryProjectIdValue = showTaskEntryProjectId?.collectAsStateWithLifecycle()?.value
     LaunchedEffect(showTaskEntryValue) {
         if (showTaskEntryValue == true) {
+            taskEntryDefaultProjectId = showTaskEntryProjectIdValue
             showTaskEntrySheet = true
             onShowTaskEntryConsumed()
         }
+    }
+
+    // Handle widget title click → navigate to matching screen
+    val navigateToViewValue = navigateToView?.collectAsStateWithLifecycle()?.value
+    LaunchedEffect(navigateToViewValue) {
+        val (viewType, viewId) = navigateToViewValue ?: return@LaunchedEffect
+        when (viewType) {
+            "TODAY" -> navController.navigate(TodayRoute) { launchSingleTop = true }
+            "INBOX" -> navController.navigate(InboxRoute) { launchSingleTop = true }
+            "UPCOMING" -> navController.navigate(UpcomingRoute) { launchSingleTop = true }
+            "ANYTIME" -> navController.navigate(AnytimeRoute) { launchSingleTop = true }
+            "PROJECT" -> {
+                val projectId = viewId.toLongOrNull()
+                if (projectId != null) {
+                    navController.navigate(ProjectRoute(projectId)) { launchSingleTop = true }
+                }
+            }
+            "CUSTOM_LIST" -> {
+                if (viewId.isNotBlank()) {
+                    navController.navigate(CustomListRoute(viewId)) { launchSingleTop = true }
+                }
+            }
+        }
+        onNavigateToViewConsumed()
     }
 
     // Handle share intent → open TaskEntrySheet with shared content

--- a/app/src/main/java/com/rendyhd/vicu/ui/components/picker/ProjectPickerDialog.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/components/picker/ProjectPickerDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,13 +40,22 @@ fun ProjectPickerDialog(
     selectedProjectId: Long?,
     onProjectSelected: (Long) -> Unit,
     onDismiss: () -> Unit,
+    inboxProjectId: Long = 0L,
 ) {
+    val sorted = remember(projects, inboxProjectId) {
+        projects.filter { !it.isArchived }
+            .sortedWith(
+                compareBy<Project> { it.id != inboxProjectId }
+                    .thenBy { it.parentProjectId }
+                    .thenBy { it.position },
+            )
+    }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Move to project") },
         text = {
             LazyColumn {
-                items(projects.filter { !it.isArchived }, key = { it.id }) { project ->
+                items(sorted, key = { it.id }) { project ->
                     val isSelected = project.id == selectedProjectId
                     val indent = if (project.parentProjectId > 0) 24.dp else 0.dp
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
@@ -96,6 +96,9 @@ fun CustomListDialog(
     var selectedLabelIds by remember {
         mutableStateOf(customList?.filter?.labelIds?.toSet() ?: emptySet())
     }
+    var addToProjectId by remember {
+        mutableStateOf(customList?.filter?.addToProjectId ?: 0L)
+    }
     var includeDone by remember { mutableStateOf(customList?.filter?.includeDone ?: false) }
     var includeTodayAllProjects by remember {
         mutableStateOf(customList?.filter?.includeTodayAllProjects ?: false)
@@ -301,6 +304,23 @@ fun CustomListDialog(
                 HorizontalDivider()
                 Spacer(modifier = Modifier.height(12.dp))
 
+                // Add tasks to project
+                Text(
+                    text = "Add tasks to",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                AddToProjectSelector(
+                    projects = projects.filter { !it.isArchived },
+                    selectedProjectId = addToProjectId,
+                    onSelect = { addToProjectId = it },
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(12.dp))
+
                 // Toggles
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -338,6 +358,7 @@ fun CustomListDialog(
                                 filter = CustomListFilter(
                                     projectIds = selectedProjectIds.toList(),
                                     projectFilterMode = projectFilterMode,
+                                    addToProjectId = addToProjectId,
                                     sortBy = sortBy,
                                     orderBy = orderBy,
                                     dueDateFilter = dueDateFilter,
@@ -402,6 +423,54 @@ private fun DropdownSelector(
                     text = { Text(displayLabel) },
                     onClick = {
                         onSelect(value)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddToProjectSelector(
+    projects: List<Project>,
+    selectedProjectId: Long,
+    onSelect: (Long) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedName = if (selectedProjectId == 0L) "Inbox (default)"
+    else projects.find { it.id == selectedProjectId }?.title ?: "Inbox (default)"
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selectedName,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("Inbox (default)") },
+                onClick = {
+                    onSelect(0L)
+                    expanded = false
+                },
+            )
+            projects.forEach { project ->
+                DropdownMenuItem(
+                    text = { Text(project.title) },
+                    onClick = {
+                        onSelect(project.id)
                         expanded = false
                     },
                 )

--- a/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
@@ -29,6 +29,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -84,6 +87,9 @@ fun CustomListDialog(
     var selectedProjectIds by remember {
         mutableStateOf(customList?.filter?.projectIds?.toSet() ?: emptySet())
     }
+    var projectFilterMode by remember {
+        mutableStateOf(customList?.filter?.projectFilterMode ?: "include")
+    }
     var sortBy by remember { mutableStateOf(customList?.filter?.sortBy ?: "due_date") }
     var orderBy by remember { mutableStateOf(customList?.filter?.orderBy ?: "asc") }
     var dueDateFilter by remember { mutableStateOf(customList?.filter?.dueDateFilter ?: "all") }
@@ -120,6 +126,23 @@ fun CustomListDialog(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    SegmentedButton(
+                        selected = projectFilterMode == "include",
+                        onClick = { projectFilterMode = "include" },
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    ) {
+                        Text("Include")
+                    }
+                    SegmentedButton(
+                        selected = projectFilterMode == "exclude",
+                        onClick = { projectFilterMode = "exclude" },
+                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    ) {
+                        Text("Exclude")
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -128,8 +151,12 @@ fun CustomListDialog(
                     tonalElevation = 1.dp,
                 ) {
                     Text(
-                        text = if (selectedProjectIds.isEmpty()) "All projects"
-                        else "${selectedProjectIds.size} selected",
+                        text = if (selectedProjectIds.isEmpty()) {
+                            if (projectFilterMode == "exclude") "None excluded" else "All projects"
+                        } else {
+                            if (projectFilterMode == "exclude") "${selectedProjectIds.size} excluded"
+                            else "${selectedProjectIds.size} included"
+                        },
                         modifier = Modifier.padding(12.dp),
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -310,6 +337,7 @@ fun CustomListDialog(
                                 icon = customList?.icon ?: "",
                                 filter = CustomListFilter(
                                     projectIds = selectedProjectIds.toList(),
+                                    projectFilterMode = projectFilterMode,
                                     sortBy = sortBy,
                                     orderBy = orderBy,
                                     dueDateFilter = dueDateFilter,

--- a/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/components/shared/CustomListDialog.kt
@@ -81,7 +81,15 @@ fun CustomListDialog(
     labels: List<Label>,
     onSave: (CustomList) -> Unit,
     onDismiss: () -> Unit,
+    inboxProjectId: Long = 0L,
 ) {
+    val sortedProjects = remember(projects, inboxProjectId) {
+        projects.filter { !it.isArchived }
+            .sortedWith(
+                compareBy<Project> { it.id != inboxProjectId }
+                    .thenBy { it.position },
+            )
+    }
     val isEdit = customList != null
     var name by remember { mutableStateOf(customList?.name ?: "") }
     var selectedProjectIds by remember {
@@ -167,7 +175,7 @@ fun CustomListDialog(
                 if (showProjectPicker) {
                     LazyColumn(modifier = Modifier.heightIn(max = 150.dp)) {
                         items(
-                            projects.filter { !it.isArchived },
+                            sortedProjects,
                             key = { it.id },
                         ) { project ->
                             Row(
@@ -312,7 +320,7 @@ fun CustomListDialog(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 AddToProjectSelector(
-                    projects = projects.filter { !it.isArchived },
+                    projects = sortedProjects,
                     selectedProjectId = addToProjectId,
                     onSelect = { addToProjectId = it },
                 )

--- a/app/src/main/java/com/rendyhd/vicu/ui/components/task/TaskEntrySheet.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/components/task/TaskEntrySheet.kt
@@ -320,6 +320,7 @@ fun TaskEntrySheet(
             selectedProjectId = state.projectId,
             onProjectSelected = viewModel::setProjectId,
             onDismiss = { showProjectPicker = false },
+            inboxProjectId = state.inboxProjectId,
         )
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/navigation/DrawerContent.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/navigation/DrawerContent.kt
@@ -1,5 +1,6 @@
 package com.rendyhd.vicu.ui.navigation
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -7,23 +8,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.AllInclusive
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.DragHandle
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.FilterList
@@ -34,19 +32,25 @@ import androidx.compose.material.icons.outlined.WbSunny
 import com.rendyhd.vicu.domain.model.BottomBarSlotType
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import sh.calvin.reorderable.ReorderableColumn
 
 private val SmartListTodayColor = Color(0xFFEAB308)
 private val SmartListUpcomingColor = Color(0xFF3B82F6)
@@ -62,7 +66,10 @@ fun DrawerContent(
     onToggleLists: () -> Unit,
     onToggleTags: () -> Unit,
     onCreateNewList: () -> Unit = {},
+    onReorderProject: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
+    onReorderList: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
 ) {
+    val hapticFeedback = LocalHapticFeedback.current
     ModalDrawerSheet(modifier = Modifier.width(300.dp)) {
         Column(modifier = Modifier.fillMaxHeight()) {
             LazyColumn(
@@ -133,13 +140,61 @@ fun DrawerContent(
                     )
                 }
                 if (state.projectsExpanded) {
-                    state.projectTree.forEach { node ->
-                        item(key = "project_${node.project.id}") {
-                            ProjectItem(
-                                project = node.project,
-                                selected = currentRoute == "ProjectRoute/${node.project.id}",
-                                onClick = { onNavigate(ProjectRoute(node.project.id)) },
-                            )
+                    item(key = "projects_reorderable") {
+                        ReorderableColumn(
+                            list = state.projectTree,
+                            onSettle = { fromIndex, toIndex ->
+                                onReorderProject(fromIndex, toIndex)
+                            },
+                            onMove = {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            },
+                        ) { _, node, isDragging ->
+                            key(node.project.id) {
+                                val elevation = animateDpAsState(
+                                    if (isDragging) 4.dp else 0.dp,
+                                    label = "dragElevation",
+                                )
+                                val folderColor = parseHexColor(node.project.hexColor)
+                                Surface(
+                                    shadowElevation = elevation.value,
+                                    color = if (isDragging) {
+                                        MaterialTheme.colorScheme.surfaceContainerHigh
+                                    } else {
+                                        Color.Transparent
+                                    },
+                                ) {
+                                    NavigationDrawerItem(
+                                        label = { Text(node.project.title) },
+                                        icon = {
+                                            Icon(
+                                                Icons.Outlined.Folder,
+                                                contentDescription = null,
+                                                tint = folderColor
+                                                    ?: MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        },
+                                        badge = {
+                                            IconButton(
+                                                modifier = Modifier.draggableHandle(),
+                                                onClick = {},
+                                            ) {
+                                                Icon(
+                                                    Icons.Outlined.DragHandle,
+                                                    contentDescription = "Reorder",
+                                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    modifier = Modifier.size(18.dp),
+                                                )
+                                            }
+                                        },
+                                        selected = currentRoute == "ProjectRoute/${node.project.id}",
+                                        onClick = { onNavigate(ProjectRoute(node.project.id)) },
+                                        modifier = Modifier.padding(
+                                            NavigationDrawerItemDefaults.ItemPadding,
+                                        ),
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -156,20 +211,60 @@ fun DrawerContent(
                     )
                 }
                 if (state.listsExpanded) {
-                    items(state.customLists, key = { "list_${it.id}" }) { list ->
-                        NavigationDrawerItem(
-                            label = { Text(list.name) },
-                            icon = {
-                                Icon(
-                                    Icons.Outlined.FilterList,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                    item(key = "lists_reorderable") {
+                        ReorderableColumn(
+                            list = state.customLists,
+                            onSettle = { fromIndex, toIndex ->
+                                onReorderList(fromIndex, toIndex)
                             },
-                            selected = currentRoute == "CustomListRoute/${list.id}",
-                            onClick = { onNavigate(CustomListRoute(list.id)) },
-                            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-                        )
+                            onMove = {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            },
+                        ) { _, list, isDragging ->
+                            key(list.id) {
+                                val elevation = animateDpAsState(
+                                    if (isDragging) 4.dp else 0.dp,
+                                    label = "dragElevation",
+                                )
+                                Surface(
+                                    shadowElevation = elevation.value,
+                                    color = if (isDragging) {
+                                        MaterialTheme.colorScheme.surfaceContainerHigh
+                                    } else {
+                                        Color.Transparent
+                                    },
+                                ) {
+                                    NavigationDrawerItem(
+                                        label = { Text(list.name) },
+                                        icon = {
+                                            Icon(
+                                                Icons.Outlined.FilterList,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        },
+                                        badge = {
+                                            IconButton(
+                                                modifier = Modifier.draggableHandle(),
+                                                onClick = {},
+                                            ) {
+                                                Icon(
+                                                    Icons.Outlined.DragHandle,
+                                                    contentDescription = "Reorder",
+                                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    modifier = Modifier.size(18.dp),
+                                                )
+                                            }
+                                        },
+                                        selected = currentRoute == "CustomListRoute/${list.id}",
+                                        onClick = { onNavigate(CustomListRoute(list.id)) },
+                                        modifier = Modifier.padding(
+                                            NavigationDrawerItemDefaults.ItemPadding,
+                                        ),
+                                    )
+                                }
+                            }
+                        }
                     }
                     item(key = "new_list") {
                         NavigationDrawerItem(
@@ -303,28 +398,6 @@ private fun SectionHeader(
             modifier = Modifier.size(20.dp),
         )
     }
-}
-
-@Composable
-private fun ProjectItem(
-    project: com.rendyhd.vicu.domain.model.Project,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    val folderColor = parseHexColor(project.hexColor)
-    NavigationDrawerItem(
-        label = { Text(project.title) },
-        icon = {
-            Icon(
-                Icons.Outlined.Folder,
-                contentDescription = null,
-                tint = folderColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-        selected = selected,
-        onClick = onClick,
-        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-    )
 }
 
 private fun parseHexColor(hex: String): Color? {

--- a/app/src/main/java/com/rendyhd/vicu/ui/navigation/DrawerViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/navigation/DrawerViewModel.kt
@@ -35,6 +35,7 @@ data class DrawerUiState(
     val listsExpanded: Boolean = true,
     val tagsExpanded: Boolean = true,
     val bottomBarSlots: List<BottomBarSlot> = BottomBarSlot.DEFAULT_SLOTS,
+    val inboxProjectId: Long = 0L,
 ) {
     val displacedSmartLists: Set<BottomBarSlotType>
         get() {
@@ -49,7 +50,7 @@ data class DrawerUiState(
 
 @HiltViewModel
 class DrawerViewModel @Inject constructor(
-    projectRepository: ProjectRepository,
+    private val projectRepository: ProjectRepository,
     labelRepository: LabelRepository,
     private val customListStore: CustomListStore,
     private val authManager: AuthManager,
@@ -111,6 +112,7 @@ class DrawerViewModel @Inject constructor(
             listsExpanded = expanded.second,
             tagsExpanded = expanded.third,
             bottomBarSlots = slots,
+            inboxProjectId = inboxId ?: 0L,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DrawerUiState())
 
@@ -135,6 +137,29 @@ class DrawerViewModel @Inject constructor(
     fun saveCustomList(customList: CustomList) {
         viewModelScope.launch {
             customListStore.save(customList)
+        }
+    }
+
+    fun reorderProject(fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            val roots = uiState.value.projectTree.map { it.project }
+            if (fromIndex == toIndex || fromIndex !in roots.indices || toIndex !in roots.indices) return@launch
+            val mutable = roots.toMutableList()
+            val moved = mutable.removeAt(fromIndex)
+            mutable.add(toIndex, moved)
+            val newPos = when {
+                mutable.size == 1 -> 1.0
+                toIndex == 0 -> (mutable.getOrNull(1)?.position ?: 1.0) / 2.0
+                toIndex == mutable.lastIndex -> mutable[toIndex - 1].position + 1.0
+                else -> (mutable[toIndex - 1].position + mutable[toIndex + 1].position) / 2.0
+            }
+            projectRepository.update(moved.copy(position = newPos))
+        }
+    }
+
+    fun reorderCustomList(fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            customListStore.reorder(fromIndex, toIndex)
         }
     }
 }

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListScreen.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListScreen.kt
@@ -67,8 +67,9 @@ fun CustomListScreen(
             )
         },
         floatingActionButton = {
+            val addToProject = state.customList?.filter?.addToProjectId?.takeIf { it != 0L }
             VicuFab(
-                onClick = { onShowTaskEntry(null, null) },
+                onClick = { onShowTaskEntry(addToProject, null) },
                 listState = listState,
             )
         },

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListScreen.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListScreen.kt
@@ -154,6 +154,7 @@ fun CustomListScreen(
                 showEditDialog = false
             },
             onDismiss = { showEditDialog = false },
+            inboxProjectId = state.inboxProjectId,
         )
     }
 }

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/customlist/CustomListViewModel.kt
@@ -3,6 +3,7 @@ package com.rendyhd.vicu.ui.screens.customlist
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rendyhd.vicu.auth.AuthManager
 import com.rendyhd.vicu.data.local.CustomListStore
 import com.rendyhd.vicu.domain.model.CustomList
 import com.rendyhd.vicu.domain.model.Label
@@ -30,6 +31,7 @@ data class CustomListUiState(
     val isRefreshing: Boolean = false,
     val error: String? = null,
     val completedTaskIds: Set<Long> = emptySet(),
+    val inboxProjectId: Long = 0L,
 )
 
 @HiltViewModel
@@ -39,6 +41,7 @@ class CustomListViewModel @Inject constructor(
     private val projectRepository: ProjectRepository,
     private val labelRepository: LabelRepository,
     private val customListStore: CustomListStore,
+    private val authManager: AuthManager,
 ) : ViewModel() {
 
     private val listId: String = savedStateHandle["listId"]!!
@@ -60,6 +63,10 @@ class CustomListViewModel @Inject constructor(
                     loadTasks(customList)
                 }
             }
+        }
+        viewModelScope.launch {
+            val inboxId = authManager.getInboxProjectId() ?: 0L
+            _uiState.update { it.copy(inboxProjectId = inboxId) }
         }
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsScreen.kt
@@ -282,6 +282,7 @@ fun SettingsScreen(
                 showCustomListDialog = false
                 editingCustomList = null
             },
+            inboxProjectId = state.inboxProjectId ?: 0L,
         )
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsScreen.kt
@@ -169,6 +169,8 @@ fun SettingsScreen(
                     onDeleteCustomList = { deletingCustomList = it },
                     onEditBottomBarSlot = { index -> editingSlotIndex = index },
                     onResetBottomBar = viewModel::resetBottomBar,
+                    onSetWidgetSmartAdd = viewModel::setWidgetSmartAdd,
+                    onSetWidgetContextNav = viewModel::setWidgetContextNav,
                     onTriggerSync = viewModel::triggerSync,
                     onRetryFailed = viewModel::retryFailedActions,
                     onClearFailed = viewModel::clearFailedActions,
@@ -429,6 +431,8 @@ private fun GeneralTab(
     onDeleteCustomList: (CustomList) -> Unit,
     onEditBottomBarSlot: (Int) -> Unit,
     onResetBottomBar: () -> Unit,
+    onSetWidgetSmartAdd: (Boolean) -> Unit,
+    onSetWidgetContextNav: (Boolean) -> Unit,
     onTriggerSync: () -> Unit,
     onRetryFailed: () -> Unit,
     onClearFailed: () -> Unit,
@@ -596,6 +600,67 @@ private fun GeneralTab(
         }
 
         item(key = "bottombar_divider") {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        }
+
+        // === Widget section ===
+        item(key = "widget_header") {
+            Text(
+                text = "Widget",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+            )
+        }
+
+        item(key = "widget_smart_add") {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Smart add button", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Add tasks to the widget's project or list target",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = state.widgetSmartAdd,
+                    onCheckedChange = onSetWidgetSmartAdd,
+                )
+            }
+        }
+
+        item(key = "widget_context_nav") {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Context navigation", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Tapping the widget title opens the matching screen",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = state.widgetContextNav,
+                    onCheckedChange = onSetWidgetContextNav,
+                )
+            }
+        }
+
+        item(key = "widget_divider") {
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsViewModel.kt
@@ -32,6 +32,7 @@ import com.rendyhd.vicu.notification.DailySummaryScheduler
 import com.rendyhd.vicu.notification.NotificationChannelManager
 import com.rendyhd.vicu.util.NetworkMonitor
 import com.rendyhd.vicu.util.NetworkResult
+import com.rendyhd.vicu.widget.WidgetUpdateScheduler
 import com.rendyhd.vicu.worker.SyncScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -225,6 +226,7 @@ class SettingsViewModel @Inject constructor(
             customListStore.clear()
             bottomBarPrefsStore.clear()
             authManager.logout() // calls POST /user/logout internally
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(appContext)
         }
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.rendyhd.vicu.data.local.NotificationPrefs
 import com.rendyhd.vicu.data.local.NotificationPrefsStore
 import com.rendyhd.vicu.data.local.ThemeMode
 import com.rendyhd.vicu.data.local.ThemePrefsStore
+import com.rendyhd.vicu.data.local.WidgetPrefsStore
 import com.rendyhd.vicu.util.parser.ParserConfig
 import com.rendyhd.vicu.util.parser.SyntaxMode
 import com.rendyhd.vicu.data.local.VikunjaDatabase
@@ -66,6 +67,9 @@ data class SettingsUiState(
     val isOnline: Boolean = true,
     // Bottom Bar
     val bottomBarSlots: List<BottomBarSlot> = BottomBarSlot.DEFAULT_SLOTS,
+    // Widget
+    val widgetSmartAdd: Boolean = true,
+    val widgetContextNav: Boolean = true,
     // Messages
     val error: String? = null,
     val successMessage: String? = null,
@@ -84,6 +88,7 @@ class SettingsViewModel @Inject constructor(
     private val nlpPrefsStore: NlpPrefsStore,
     private val bottomBarPrefsStore: BottomBarPrefsStore,
     private val dailySummaryScheduler: DailySummaryScheduler,
+    private val widgetPrefsStore: WidgetPrefsStore,
     private val pendingActionDao: PendingActionDao,
     private val networkMonitor: NetworkMonitor,
     private val database: VikunjaDatabase,
@@ -126,7 +131,13 @@ class SettingsViewModel @Inject constructor(
         ) { userInfo, url, inboxId, bbSlots ->
             listOf(userInfo, url, inboxId, bbSlots)
         },
-    ) { base, syncTheme, userEtc ->
+        combine(
+            widgetPrefsStore.smartAdd,
+            widgetPrefsStore.contextNav,
+        ) { smartAdd, contextNav ->
+            listOf(smartAdd, contextNav)
+        },
+    ) { base, syncTheme, userEtc, widgetPrefs ->
         @Suppress("UNCHECKED_CAST")
         val labels = base[0] as List<Label>
         val customLists = base[1] as List<CustomList>
@@ -142,6 +153,8 @@ class SettingsViewModel @Inject constructor(
         val url = userEtc[1] as String
         val inboxId = userEtc[2] as Long?
         val bbSlots = userEtc[3] as List<BottomBarSlot>
+        val smartAdd = widgetPrefs[0] as Boolean
+        val contextNav = widgetPrefs[1] as Boolean
         SettingsUiState(
             username = userInfo.first,
             email = userInfo.second,
@@ -158,6 +171,8 @@ class SettingsViewModel @Inject constructor(
             failedActionCount = failedCount,
             isOnline = isOnline,
             bottomBarSlots = bbSlots,
+            widgetSmartAdd = smartAdd,
+            widgetContextNav = contextNav,
             error = messages.first,
             successMessage = messages.second,
         )
@@ -376,6 +391,22 @@ class SettingsViewModel @Inject constructor(
             _messages.update { null to "Test notification sent" }
         } catch (_: SecurityException) {
             _messages.update { "Notification permission not granted" to null }
+        }
+    }
+
+    // --- Widget ---
+
+    fun setWidgetSmartAdd(enabled: Boolean) {
+        viewModelScope.launch {
+            widgetPrefsStore.setSmartAdd(enabled)
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(appContext)
+        }
+    }
+
+    fun setWidgetContextNav(enabled: Boolean) {
+        viewModelScope.launch {
+            widgetPrefsStore.setContextNav(enabled)
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(appContext)
         }
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/setup/SetupViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/setup/SetupViewModel.kt
@@ -15,7 +15,10 @@ import com.rendyhd.vicu.data.remote.api.OidcProviderDto
 import com.rendyhd.vicu.data.remote.api.VikunjaApiService
 import com.rendyhd.vicu.data.remote.interceptor.BaseUrlHolder
 import com.rendyhd.vicu.domain.model.Project
+import com.rendyhd.vicu.widget.WidgetUpdateScheduler
+import android.content.Context
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -57,6 +60,7 @@ data class SetupUiState(
 
 @HiltViewModel
 class SetupViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val apiService: dagger.Lazy<VikunjaApiService>,
     private val authManager: AuthManager,
     private val baseUrlHolder: BaseUrlHolder,
@@ -250,6 +254,7 @@ class SetupViewModel @Inject constructor(
         viewModelScope.launch {
             authManager.onInboxProjectSelected(projectId)
             _uiState.update { it.copy(setupComplete = true) }
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(appContext)
         }
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailScreen.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailScreen.kt
@@ -494,6 +494,7 @@ fun TaskDetailSheet(
             selectedProjectId = state.task?.projectId,
             onProjectSelected = viewModel::setProject,
             onDismiss = { showProjectPicker = false },
+            inboxProjectId = state.inboxProjectId,
         )
     }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.rendyhd.vicu.domain.model.Label
 import com.rendyhd.vicu.domain.model.Project
 import com.rendyhd.vicu.domain.model.Task
 import com.rendyhd.vicu.domain.model.TaskReminder
+import com.rendyhd.vicu.auth.AuthManager
 import com.rendyhd.vicu.domain.repository.AttachmentRepository
 import com.rendyhd.vicu.domain.repository.LabelRepository
 import com.rendyhd.vicu.domain.repository.ProjectRepository
@@ -38,6 +39,7 @@ data class TaskDetailUiState(
     val attachments: List<Attachment> = emptyList(),
     val showDeleteConfirmation: Boolean = false,
     val isDeleted: Boolean = false,
+    val inboxProjectId: Long = 0L,
 )
 
 @HiltViewModel
@@ -46,6 +48,7 @@ class TaskDetailViewModel @Inject constructor(
     private val labelRepository: LabelRepository,
     private val attachmentRepository: AttachmentRepository,
     private val projectRepository: ProjectRepository,
+    private val authManager: AuthManager,
 ) : ViewModel() {
 
     companion object {
@@ -100,6 +103,11 @@ class TaskDetailViewModel @Inject constructor(
             projectRepository.getAll().collect { projects ->
                 _uiState.update { it.copy(allProjects = projects) }
             }
+        }
+
+        viewModelScope.launch {
+            val inboxId = authManager.getInboxProjectId() ?: 0L
+            _uiState.update { it.copy(inboxProjectId = inboxId) }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/taskentry/TaskEntryViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/taskentry/TaskEntryViewModel.kt
@@ -58,6 +58,7 @@ data class TaskEntryUiState(
     val suppressedTypes: Set<TokenType> = emptySet(),
     val pendingAttachmentUris: List<Uri> = emptyList(),
     val pendingAttachmentMimeType: String? = null,
+    val inboxProjectId: Long = 0L,
 )
 
 @HiltViewModel
@@ -89,6 +90,10 @@ class TaskEntryViewModel @Inject constructor(
             labelRepository.getAll().collect { labels ->
                 _uiState.update { it.copy(allLabels = labels) }
             }
+        }
+        viewModelScope.launch {
+            val inboxId = authManager.getInboxProjectId() ?: 0L
+            _uiState.update { it.copy(inboxProjectId = inboxId) }
         }
         viewModelScope.launch {
             nlpPrefsStore.config.collect { config ->

--- a/app/src/main/java/com/rendyhd/vicu/util/CustomListFilterBuilder.kt
+++ b/app/src/main/java/com/rendyhd/vicu/util/CustomListFilterBuilder.kt
@@ -23,8 +23,8 @@ object CustomListFilterBuilder {
             parts.add("done = false")
         }
 
-        // Single project filter (API only supports one)
-        if (filter.projectIds.size == 1) {
+        // Single project filter (API only supports one; exclude mode uses client-side only)
+        if (filter.projectFilterMode != "exclude" && filter.projectIds.size == 1) {
             parts.add("project_id = ${filter.projectIds.first()}")
         }
 
@@ -62,8 +62,8 @@ object CustomListFilterBuilder {
             // "all" -> no due date filter
         }
 
-        // Include today from all projects (union mode)
-        if (filter.includeTodayAllProjects && filter.projectIds.isNotEmpty()) {
+        // Include today from all projects (union mode) — only for include mode
+        if (filter.projectFilterMode != "exclude" && filter.includeTodayAllProjects && filter.projectIds.isNotEmpty()) {
             val endOfToday = now.plusDays(1).atStartOfDay().minusNanos(1).toInstant(ZoneOffset.UTC)
             val startOfToday = now.atStartOfDay().toInstant(ZoneOffset.UTC)
             val projectFilter = if (filter.projectIds.size == 1) {
@@ -98,15 +98,26 @@ object CustomListFilterBuilder {
     fun applyClientSideFilters(tasks: List<Task>, filter: CustomListFilter): List<Task> {
         var result = tasks
 
-        // Project filter (handles both single and multi-project)
+        // Project filter (handles include and exclude modes)
         if (filter.projectIds.isNotEmpty()) {
-            if (filter.includeTodayAllProjects) {
-                // Union: tasks in specified projects OR tasks due today from any project
-                result = result.filter { task ->
-                    task.projectId in filter.projectIds || isTaskDueToday(task.dueDate)
+            if (filter.projectFilterMode == "exclude") {
+                // Exclude mode: remove tasks from the selected projects
+                if (filter.includeTodayAllProjects) {
+                    result = result.filter { task ->
+                        task.projectId !in filter.projectIds || isTaskDueToday(task.dueDate)
+                    }
+                } else {
+                    result = result.filter { it.projectId !in filter.projectIds }
                 }
             } else {
-                result = result.filter { it.projectId in filter.projectIds }
+                // Include mode (default)
+                if (filter.includeTodayAllProjects) {
+                    result = result.filter { task ->
+                        task.projectId in filter.projectIds || isTaskDueToday(task.dueDate)
+                    }
+                } else {
+                    result = result.filter { it.projectId in filter.projectIds }
+                }
             }
         }
 

--- a/app/src/main/java/com/rendyhd/vicu/widget/TaskListWidget.kt
+++ b/app/src/main/java/com/rendyhd/vicu/widget/TaskListWidget.kt
@@ -155,7 +155,18 @@ private fun ScrollableWidget(state: TaskWidgetState) {
     ) {
         WidgetHeader(state)
         Spacer(modifier = GlanceModifier.height(8.dp))
-        if (state.tasks.isEmpty()) {
+        if (state.error != null) {
+            Box(
+                modifier = GlanceModifier.fillMaxSize()
+                    .clickable(actionStartActivity<MainActivity>()),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = state.error,
+                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 14.sp),
+                )
+            }
+        } else if (state.tasks.isEmpty()) {
             Box(
                 modifier = GlanceModifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/rendyhd/vicu/widget/TaskListWidget.kt
+++ b/app/src/main/java/com/rendyhd/vicu/widget/TaskListWidget.kt
@@ -92,9 +92,31 @@ private val medPriorityColor = ColorProvider(
 
 // Action callbacks for deep linking
 class OpenTaskEntryAction : ActionCallback {
+    companion object {
+        val DefaultProjectIdKey = ActionParameters.Key<Long>("default_project_id")
+    }
     override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
         val intent = Intent(context, MainActivity::class.java).apply {
             putExtra("show_task_entry", true)
+            val projectId = parameters[DefaultProjectIdKey] ?: 0L
+            if (projectId != 0L) {
+                putExtra("default_project_id", projectId)
+            }
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        context.startActivity(intent)
+    }
+}
+
+class OpenWidgetViewAction : ActionCallback {
+    companion object {
+        val ViewTypeKey = ActionParameters.Key<String>("view_type")
+        val ViewIdKey = ActionParameters.Key<String>("view_id")
+    }
+    override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            putExtra("navigate_to_view_type", parameters[ViewTypeKey] ?: "")
+            putExtra("navigate_to_view_id", parameters[ViewIdKey] ?: "")
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
         context.startActivity(intent)
@@ -115,6 +137,39 @@ class OpenTaskDetailAction : ActionCallback {
     }
 }
 
+/**
+ * Resolves which project the + button should add tasks to, based on the widget state.
+ * - PROJECT widget → that project's ID
+ * - CUSTOM_LIST widget → the list's addToProjectId (0 = inbox)
+ * - Everything else → 0 (inbox)
+ */
+private fun resolveAddProjectId(state: TaskWidgetState): Long {
+    if (!state.smartAdd) return 0L
+    return when (state.viewType) {
+        WidgetViewType.PROJECT -> state.viewId.toLongOrNull() ?: 0L
+        WidgetViewType.CUSTOM_LIST -> state.addToProjectId
+        else -> 0L
+    }
+}
+
+/**
+ * Builds the click action for the widget title.
+ * When contextNav is enabled, navigates to the matching screen.
+ * Otherwise, just opens the app.
+ */
+@Composable
+private fun titleClickAction(state: TaskWidgetState) =
+    if (state.contextNav) {
+        actionRunCallback<OpenWidgetViewAction>(
+            actionParametersOf(
+                OpenWidgetViewAction.ViewTypeKey to state.viewType.name,
+                OpenWidgetViewAction.ViewIdKey to state.viewId,
+            )
+        )
+    } else {
+        actionStartActivity<MainActivity>()
+    }
+
 @Composable
 private fun CompactWidget(state: TaskWidgetState) {
     Box(
@@ -122,7 +177,7 @@ private fun CompactWidget(state: TaskWidgetState) {
             .fillMaxSize()
             .cornerRadius(16.dp)
             .background(GlanceTheme.colors.widgetBackground)
-            .clickable(actionStartActivity<MainActivity>())
+            .clickable(titleClickAction(state))
             .padding(16.dp),
         contentAlignment = Alignment.CenterStart,
     ) {
@@ -139,7 +194,7 @@ private fun CompactWidget(state: TaskWidgetState) {
                 ),
                 modifier = GlanceModifier.defaultWeight(),
             )
-            AddButton()
+            AddButton(state)
         }
     }
 }
@@ -201,21 +256,29 @@ private fun WidgetHeader(state: TaskWidgetState) {
             ),
             modifier = GlanceModifier
                 .defaultWeight()
-                .clickable(actionStartActivity<MainActivity>()),
+                .clickable(titleClickAction(state)),
         )
-        AddButton()
+        AddButton(state)
     }
 }
 
 @Composable
-private fun AddButton() {
+private fun AddButton(state: TaskWidgetState) {
+    val projectId = resolveAddProjectId(state)
+    val action = if (projectId != 0L) {
+        actionRunCallback<OpenTaskEntryAction>(
+            actionParametersOf(OpenTaskEntryAction.DefaultProjectIdKey to projectId)
+        )
+    } else {
+        actionRunCallback<OpenTaskEntryAction>()
+    }
     Box(
         modifier = GlanceModifier
             .height(36.dp)
             .width(46.dp)
             .cornerRadius(18.dp)
             .background(GlanceTheme.colors.primary)
-            .clickable(actionRunCallback<OpenTaskEntryAction>()),
+            .clickable(action),
         contentAlignment = Alignment.Center,
     ) {
         Image(

--- a/app/src/main/java/com/rendyhd/vicu/widget/TaskWidgetWorker.kt
+++ b/app/src/main/java/com/rendyhd/vicu/widget/TaskWidgetWorker.kt
@@ -45,6 +45,34 @@ class TaskWidgetWorker @AssistedInject constructor(
                 return Result.success()
             }
 
+            // Auth guard: if not logged in, show message instead of stale data
+            val isLoggedIn = secureTokenStorage.getVikunjaUrl()?.isNotBlank() == true &&
+                (secureTokenStorage.getJwt()?.isNotBlank() == true || secureTokenStorage.getApiToken()?.isNotBlank() == true)
+
+            if (!isLoggedIn) {
+                Log.d(TAG, "User not logged in, showing login prompt on all widgets")
+                for (glanceId in glanceIds) {
+                    val state = TaskWidgetState(
+                        tasks = emptyList(),
+                        totalCount = 0,
+                        lastUpdated = DateUtils.nowIso(),
+                        error = "Log in to see your tasks",
+                    )
+                    updateAppWidgetState(
+                        applicationContext,
+                        TaskWidgetStateDefinition,
+                        glanceId,
+                    ) { prefs ->
+                        prefs.toMutablePreferences().apply {
+                            this[TaskWidgetStateDefinition.KEY_STATE] =
+                                TaskWidgetStateDefinition.encodeState(state)
+                        }
+                    }
+                    TaskListWidget().update(applicationContext, glanceId)
+                }
+                return Result.success()
+            }
+
             val singleWidgetId = inputData.getInt("app_widget_id", -1)
             val updateAll = inputData.getBoolean("update_all", false)
 

--- a/app/src/main/java/com/rendyhd/vicu/widget/TaskWidgetWorker.kt
+++ b/app/src/main/java/com/rendyhd/vicu/widget/TaskWidgetWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.rendyhd.vicu.auth.SecureTokenStorage
 import com.rendyhd.vicu.data.local.CustomListStore
+import com.rendyhd.vicu.data.local.WidgetPrefsStore
 import com.rendyhd.vicu.data.local.dao.ProjectDao
 import com.rendyhd.vicu.data.local.dao.TaskDao
 import com.rendyhd.vicu.data.local.entity.TaskEntity
@@ -28,6 +29,7 @@ class TaskWidgetWorker @AssistedInject constructor(
     private val taskMapper: TaskMapper,
     private val secureTokenStorage: SecureTokenStorage,
     private val customListStore: CustomListStore,
+    private val widgetPrefsStore: WidgetPrefsStore,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -76,6 +78,10 @@ class TaskWidgetWorker @AssistedInject constructor(
             val singleWidgetId = inputData.getInt("app_widget_id", -1)
             val updateAll = inputData.getBoolean("update_all", false)
 
+            // Read widget behavior prefs
+            val smartAddEnabled = widgetPrefsStore.smartAdd.first()
+            val contextNavEnabled = widgetPrefsStore.contextNav.first()
+
             // Build project name lookup
             val projects = projectDao.getAllSync()
             val projectNameMap = projects.associate { it.id to it.title }
@@ -109,6 +115,14 @@ class TaskWidgetWorker @AssistedInject constructor(
                     )
                 }
 
+                // Resolve addToProjectId for custom lists
+                val addToProjectId = if (resolvedConfig.viewType == WidgetViewType.CUSTOM_LIST) {
+                    val cl = customListStore.getById(resolvedConfig.viewId).first()
+                    cl?.filter?.addToProjectId ?: 0L
+                } else {
+                    0L
+                }
+
                 val state = TaskWidgetState(
                     viewType = resolvedConfig.viewType,
                     viewId = resolvedConfig.viewId,
@@ -116,6 +130,9 @@ class TaskWidgetWorker @AssistedInject constructor(
                     tasks = widgetTasks,
                     totalCount = totalCount,
                     lastUpdated = DateUtils.nowIso(),
+                    smartAdd = smartAddEnabled,
+                    contextNav = contextNavEnabled,
+                    addToProjectId = addToProjectId,
                 )
 
                 updateAppWidgetState(

--- a/app/src/main/java/com/rendyhd/vicu/widget/WidgetModels.kt
+++ b/app/src/main/java/com/rendyhd/vicu/widget/WidgetModels.kt
@@ -26,6 +26,9 @@ data class TaskWidgetState(
     val totalCount: Int = 0,
     val lastUpdated: String = "",
     val error: String? = null,
+    val smartAdd: Boolean = true,
+    val contextNav: Boolean = true,
+    val addToProjectId: Long = 0L, // for custom lists: which project the + button targets
 )
 
 @Serializable

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
     <exclude domain="file" path="datastore/auth_prefs.preferences_pb" />
+    <exclude domain="file" path="datastore/widget_configs.preferences_pb" />
     <exclude domain="database" path="vicu.db" />
     <exclude domain="database" path="vicu.db-shm" />
     <exclude domain="database" path="vicu.db-wal" />

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,11 +2,13 @@
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="file" path="datastore/auth_prefs.preferences_pb" />
+        <exclude domain="file" path="datastore/widget_configs.preferences_pb" />
         <exclude domain="database" path="vicu.db" />
         <exclude domain="database" path="vicu.db-shm" />
         <exclude domain="database" path="vicu.db-wal" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="file" path="datastore/auth_prefs.preferences_pb" />
+        <exclude domain="file" path="datastore/widget_configs.preferences_pb" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false" />
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">10.0.2.2</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ glance = "1.1.1"
 coil = "3.3.0"
 appauth = "0.11.1"
 tink = "1.19.0"
+reorderable = "2.4.3"
 coreKtx = "1.16.0"
 lifecycleRuntime = "2.9.0"
 activityCompose = "1.10.1"
@@ -79,6 +80,7 @@ coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp"
 # Auth
 appauth = { group = "net.openid", name = "appauth", version.ref = "appauth" }
 tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink" }
+reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version.ref = "reorderable" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

- **Drag-and-drop reordering** for projects and custom lists in the navigation drawer using `ReorderableColumn` with haptic feedback
- **Widget sync fix**: Widgets now refresh immediately after task data syncs from server, eliminating stale completed tasks
- **HTTP cleartext support**: Allow HTTP connections for self-hosted Vikunja instances without SSL
- **Inbox pinning**: Inbox project always appears first in all project pickers and dropdowns
- **Custom list exclude mode**: Project filter supports both include and exclude modes

## Test plan

- [ ] Drag projects in drawer → verify order persists after restart
- [ ] Drag custom lists in drawer → verify order persists
- [ ] Complete a task on desktop → open Android app → verify widget updates immediately
- [ ] Enter an `http://` server URL on setup screen → should connect successfully
- [ ] Enter an `https://` URL → should still work as before
- [ ] Open project picker in task detail → verify Inbox is always first
- [ ] Create/edit a custom list with exclude mode → verify correct tasks shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)