### PR TITLE
Fix widget not syncing, endless loading spinner, and unexpected logout

### DIFF
--- a/app/src/main/java/com/rendyhd/vicu/auth/AuthManager.kt
+++ b/app/src/main/java/com/rendyhd/vicu/auth/AuthManager.kt
@@ -77,40 +77,46 @@ class AuthManager @Inject constructor(
     }
 
     suspend fun initialize() {
-        val url = tokenStorage.getVikunjaUrl()
-        if (url.isNullOrBlank()) {
-            _authState.value = AuthState.Unauthenticated
-            return
-        }
+        try {
+            val url = tokenStorage.getVikunjaUrl()
+            if (url.isNullOrBlank()) {
+                _authState.value = AuthState.Unauthenticated
+                isInitialized = true
+                return
+            }
 
-        isServerV2Cached = tokenStorage.getServerIsV2()
+            isServerV2Cached = tokenStorage.getServerIsV2()
 
-        val jwt = tokenStorage.getJwt()
-        val jwtExpiry = tokenStorage.getJwtExpiry()
-        val apiToken = tokenStorage.getApiToken()
+            val jwt = tokenStorage.getJwt()
+            val jwtExpiry = tokenStorage.getJwtExpiry()
+            val apiToken = tokenStorage.getApiToken()
 
-        when {
-            jwt != null && !isExpired(jwtExpiry) -> {
-                cachedToken = jwt
-                cachedJwtExpiry = jwtExpiry
-                _authState.value = AuthState.Authenticated
-                if (isServerV2Cached) {
-                    scheduleProactiveRefresh()
+            when {
+                jwt != null && !isExpired(jwtExpiry) -> {
+                    cachedToken = jwt
+                    cachedJwtExpiry = jwtExpiry
+                    _authState.value = AuthState.Authenticated
+                    if (isServerV2Cached) {
+                        scheduleProactiveRefresh()
+                    }
+                }
+                apiToken != null -> {
+                    cachedToken = apiToken
+                    _authState.value = AuthState.Authenticated
+                }
+                jwt != null -> {
+                    // JWT expired, no API token — need re-auth or renewal
+                    cachedToken = jwt // still try with expired JWT, authenticator will refresh
+                    cachedJwtExpiry = jwtExpiry
+                    _authState.value = AuthState.Authenticated
+                }
+                else -> {
+                    _authState.value = AuthState.Unauthenticated
                 }
             }
-            apiToken != null -> {
-                cachedToken = apiToken
-                _authState.value = AuthState.Authenticated
-            }
-            jwt != null -> {
-                // JWT expired, no API token — need re-auth or renewal
-                cachedToken = jwt // still try with expired JWT, authenticator will refresh
-                cachedJwtExpiry = jwtExpiry
-                _authState.value = AuthState.Authenticated
-            }
-            else -> {
-                _authState.value = AuthState.Unauthenticated
-            }
+        } catch (e: Exception) {
+            Log.e(TAG, "initialize() failed — tokens may be corrupted, forcing re-auth", e)
+            _authState.value = AuthState.Unauthenticated
         }
         isInitialized = true
     }

--- a/app/src/main/java/com/rendyhd/vicu/auth/SecureTokenStorage.kt
+++ b/app/src/main/java/com/rendyhd/vicu/auth/SecureTokenStorage.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import java.security.KeyStore
 import java.util.Base64
 import javax.inject.Inject
@@ -85,6 +86,29 @@ class SecureTokenStorage @Inject constructor(
         }
         // Clear the Tink keyset SharedPreferences
         context.getSharedPreferences(KEYSET_PREFS, Context.MODE_PRIVATE).edit().clear().apply()
+        // Clear encrypted tokens from DataStore — they can never be decrypted with a new key
+        clearEncryptedTokensBlocking()
+    }
+
+    /**
+     * Synchronously clear encrypted token values from DataStore.
+     * Called during [resetKeystore] (from lazy init) where coroutines aren't available.
+     */
+    private fun clearEncryptedTokensBlocking() {
+        try {
+            runBlocking {
+                context.authDataStore.edit { prefs ->
+                    prefs.remove(Keys.JWT)
+                    prefs.remove(Keys.JWT_EXPIRY)
+                    prefs.remove(Keys.API_TOKEN)
+                    prefs.remove(Keys.API_TOKEN_EXPIRY)
+                    prefs.remove(Keys.REFRESH_TOKEN)
+                }
+            }
+            Log.w(TAG, "Cleared encrypted tokens after keystore reset")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear encrypted tokens after keystore reset", e)
+        }
     }
 
     private fun encrypt(plaintext: String): String {
@@ -97,6 +121,22 @@ class SecureTokenStorage @Inject constructor(
         return String(aead.decrypt(ciphertext, null), Charsets.UTF_8)
     }
 
+    /**
+     * Attempt to decrypt; return null on failure (e.g. keystore was reset and
+     * the ciphertext was produced with a previous key).
+     */
+    private fun decryptOrNull(encoded: String): String? {
+        return try {
+            decrypt(encoded)
+        } catch (e: java.security.GeneralSecurityException) {
+            Log.w(TAG, "Decryption failed (keystore reset?), returning null", e)
+            null
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Base64 decode failed, returning null", e)
+            null
+        }
+    }
+
     // JWT
     suspend fun storeJwt(jwt: String, expiry: Long) {
         context.authDataStore.edit { prefs ->
@@ -107,7 +147,7 @@ class SecureTokenStorage @Inject constructor(
 
     suspend fun getJwt(): String? {
         val prefs = context.authDataStore.data.first()
-        return prefs[Keys.JWT]?.let { decrypt(it) }
+        return prefs[Keys.JWT]?.let { decryptOrNull(it) }
     }
 
     suspend fun getJwtExpiry(): Long {
@@ -125,7 +165,7 @@ class SecureTokenStorage @Inject constructor(
 
     suspend fun getApiToken(): String? {
         val prefs = context.authDataStore.data.first()
-        return prefs[Keys.API_TOKEN]?.let { decrypt(it) }
+        return prefs[Keys.API_TOKEN]?.let { decryptOrNull(it) }
     }
 
     suspend fun getApiTokenExpiry(): Long {
@@ -142,7 +182,7 @@ class SecureTokenStorage @Inject constructor(
 
     suspend fun getRefreshToken(): String? {
         val prefs = context.authDataStore.data.first()
-        return prefs[Keys.REFRESH_TOKEN]?.let { decrypt(it) }
+        return prefs[Keys.REFRESH_TOKEN]?.let { decryptOrNull(it) }
     }
 
     // Server version flag

--- a/app/src/main/java/com/rendyhd/vicu/data/remote/interceptor/TokenAuthenticator.kt
+++ b/app/src/main/java/com/rendyhd/vicu/data/remote/interceptor/TokenAuthenticator.kt
@@ -30,8 +30,7 @@ class TokenAuthenticator @Inject constructor(
 
     override fun authenticate(route: Route?, response: Response): Request? {
         if (responseCount(response) >= MAX_RETRIES) {
-            if (BuildConfig.DEBUG) Log.w(TAG, "Max retries reached, giving up")
-            authManager.setNeedsReAuth()
+            if (BuildConfig.DEBUG) Log.w(TAG, "Max retries reached, giving up (request fails but user stays logged in)")
             return null
         }
 

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/anytime/AnytimeViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/anytime/AnytimeViewModel.kt
@@ -52,7 +52,11 @@ class AnytimeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val inboxId = authManager.getInboxProjectId() ?: return@launch
+            val inboxId = authManager.getInboxProjectId()
+            if (inboxId == null) {
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
             combine(
                 taskRepository.getAnytimeTasks(inboxId),
                 projectRepository.getAll(),

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/inbox/InboxViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/inbox/InboxViewModel.kt
@@ -49,6 +49,7 @@ class InboxViewModel @Inject constructor(
             _uiState.update { it.copy(inboxProjectId = inboxId) }
             if (inboxId == null) {
                 Log.e(TAG, "init: inboxProjectId is NULL — Flow collection skipped!")
+                _uiState.update { it.copy(isLoading = false) }
                 return@launch
             }
             taskRepository.getInboxTasks(inboxId).collect { tasks ->

--- a/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/rendyhd/vicu/ui/screens/taskdetail/TaskDetailViewModel.kt
@@ -95,6 +95,8 @@ class TaskDetailViewModel @Inject constructor(
                             it.copy(subtasks = subtasks, isLoading = false)
                         }
                     }
+                } else {
+                    _uiState.update { it.copy(isLoading = false) }
                 }
             }
         }

--- a/app/src/main/java/com/rendyhd/vicu/worker/SyncWorker.kt
+++ b/app/src/main/java/com/rendyhd/vicu/worker/SyncWorker.kt
@@ -80,11 +80,12 @@ class SyncWorker @AssistedInject constructor(
 
             // Full refresh from server
             refreshAllFromServer()
-
-            WidgetUpdateScheduler.enqueueImmediateUpdateAll(applicationContext)
         } catch (e: Exception) {
             Log.e(TAG, "SyncWorker failed: ${e.message}", e)
             return Result.retry()
+        } finally {
+            // Always refresh widgets from Room, even if sync failed
+            WidgetUpdateScheduler.enqueueImmediateUpdateAll(applicationContext)
         }
 
         return if (hasRetriableFailures) Result.retry() else Result.success()


### PR DESCRIPTION
Root cause: unhandled decrypt exceptions in SecureTokenStorage cascade through auth initialization, leaving AuthState stuck at Loading (endless spinner), and causing premature forced re-auth (unexpected logout).

- SecureTokenStorage: add decryptOrNull() to catch decrypt failures gracefully; clear encrypted tokens from DataStore when Tink keystore resets (old ciphertexts become permanently undecryptable)
- AuthManager: wrap initialize() in try-catch so authState always transitions out of Loading, even if token storage is corrupted
- TokenAuthenticator: don't call setNeedsReAuth() on retry exhaustion (transient failures); only force re-auth when all token options are genuinely exhausted
- SyncWorker: move widget update to finally block so widgets refresh from Room even when sync fails
- InboxViewModel/AnytimeViewModel: set isLoading=false when inboxId is null instead of spinning forever
- TaskDetailViewModel: handle null task from Room Flow

https://claude.ai/code/session_01QfUd8RAhpwHW6GsTgrkNKg